### PR TITLE
Assembly isolation using WASI sandbox

### DIFF
--- a/samples/DotnetInDotnet/DotnetInDotnet.sln
+++ b/samples/DotnetInDotnet/DotnetInDotnet.sln
@@ -1,0 +1,79 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32901.215
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Filter.WasmHost", "Filter.WasmHost\Filter.WasmHost.csproj", "{806A95AC-79C6-488A-9B6C-EA26ABC8E178}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Filter.Common", "Filter.Common\Filter.Common.csproj", "{51331D44-259E-4150-92B0-AE5FCEE5A6CF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Filter.Custom", "Filter.Custom\Filter.Custom.csproj", "{5CA2614F-ABEC-4A7A-A3AC-1BBEA3B0BFF7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Filter.ExternalHost", "Filter.ExternalHost\Filter.ExternalHost.csproj", "{0E913D36-3663-47DF-B22E-75472800151D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{806A95AC-79C6-488A-9B6C-EA26ABC8E178}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{806A95AC-79C6-488A-9B6C-EA26ABC8E178}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{806A95AC-79C6-488A-9B6C-EA26ABC8E178}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{806A95AC-79C6-488A-9B6C-EA26ABC8E178}.Debug|x64.Build.0 = Debug|Any CPU
+		{806A95AC-79C6-488A-9B6C-EA26ABC8E178}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{806A95AC-79C6-488A-9B6C-EA26ABC8E178}.Debug|x86.Build.0 = Debug|Any CPU
+		{806A95AC-79C6-488A-9B6C-EA26ABC8E178}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{806A95AC-79C6-488A-9B6C-EA26ABC8E178}.Release|Any CPU.Build.0 = Release|Any CPU
+		{806A95AC-79C6-488A-9B6C-EA26ABC8E178}.Release|x64.ActiveCfg = Release|Any CPU
+		{806A95AC-79C6-488A-9B6C-EA26ABC8E178}.Release|x64.Build.0 = Release|Any CPU
+		{806A95AC-79C6-488A-9B6C-EA26ABC8E178}.Release|x86.ActiveCfg = Release|Any CPU
+		{806A95AC-79C6-488A-9B6C-EA26ABC8E178}.Release|x86.Build.0 = Release|Any CPU
+		{51331D44-259E-4150-92B0-AE5FCEE5A6CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{51331D44-259E-4150-92B0-AE5FCEE5A6CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{51331D44-259E-4150-92B0-AE5FCEE5A6CF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{51331D44-259E-4150-92B0-AE5FCEE5A6CF}.Debug|x64.Build.0 = Debug|Any CPU
+		{51331D44-259E-4150-92B0-AE5FCEE5A6CF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{51331D44-259E-4150-92B0-AE5FCEE5A6CF}.Debug|x86.Build.0 = Debug|Any CPU
+		{51331D44-259E-4150-92B0-AE5FCEE5A6CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{51331D44-259E-4150-92B0-AE5FCEE5A6CF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{51331D44-259E-4150-92B0-AE5FCEE5A6CF}.Release|x64.ActiveCfg = Release|Any CPU
+		{51331D44-259E-4150-92B0-AE5FCEE5A6CF}.Release|x64.Build.0 = Release|Any CPU
+		{51331D44-259E-4150-92B0-AE5FCEE5A6CF}.Release|x86.ActiveCfg = Release|Any CPU
+		{51331D44-259E-4150-92B0-AE5FCEE5A6CF}.Release|x86.Build.0 = Release|Any CPU
+		{5CA2614F-ABEC-4A7A-A3AC-1BBEA3B0BFF7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5CA2614F-ABEC-4A7A-A3AC-1BBEA3B0BFF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5CA2614F-ABEC-4A7A-A3AC-1BBEA3B0BFF7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5CA2614F-ABEC-4A7A-A3AC-1BBEA3B0BFF7}.Debug|x64.Build.0 = Debug|Any CPU
+		{5CA2614F-ABEC-4A7A-A3AC-1BBEA3B0BFF7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5CA2614F-ABEC-4A7A-A3AC-1BBEA3B0BFF7}.Debug|x86.Build.0 = Debug|Any CPU
+		{5CA2614F-ABEC-4A7A-A3AC-1BBEA3B0BFF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5CA2614F-ABEC-4A7A-A3AC-1BBEA3B0BFF7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5CA2614F-ABEC-4A7A-A3AC-1BBEA3B0BFF7}.Release|x64.ActiveCfg = Release|Any CPU
+		{5CA2614F-ABEC-4A7A-A3AC-1BBEA3B0BFF7}.Release|x64.Build.0 = Release|Any CPU
+		{5CA2614F-ABEC-4A7A-A3AC-1BBEA3B0BFF7}.Release|x86.ActiveCfg = Release|Any CPU
+		{5CA2614F-ABEC-4A7A-A3AC-1BBEA3B0BFF7}.Release|x86.Build.0 = Release|Any CPU
+		{0E913D36-3663-47DF-B22E-75472800151D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0E913D36-3663-47DF-B22E-75472800151D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0E913D36-3663-47DF-B22E-75472800151D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0E913D36-3663-47DF-B22E-75472800151D}.Debug|x64.Build.0 = Debug|Any CPU
+		{0E913D36-3663-47DF-B22E-75472800151D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0E913D36-3663-47DF-B22E-75472800151D}.Debug|x86.Build.0 = Debug|Any CPU
+		{0E913D36-3663-47DF-B22E-75472800151D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0E913D36-3663-47DF-B22E-75472800151D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0E913D36-3663-47DF-B22E-75472800151D}.Release|x64.ActiveCfg = Release|Any CPU
+		{0E913D36-3663-47DF-B22E-75472800151D}.Release|x64.Build.0 = Release|Any CPU
+		{0E913D36-3663-47DF-B22E-75472800151D}.Release|x86.ActiveCfg = Release|Any CPU
+		{0E913D36-3663-47DF-B22E-75472800151D}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1E057915-C3DE-4DE4-B65A-3E5F156A8B02}
+	EndGlobalSection
+EndGlobal

--- a/samples/DotnetInDotnet/Filter.Common/Filter.Common.csproj
+++ b/samples/DotnetInDotnet/Filter.Common/Filter.Common.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/samples/DotnetInDotnet/Filter.Common/IFilter.cs
+++ b/samples/DotnetInDotnet/Filter.Common/IFilter.cs
@@ -1,0 +1,11 @@
+﻿
+using System.Text.Json;
+
+namespace Filter.Common
+{
+    // this is common interface for the untrusted code which we would like to wrap in WASI sandbox
+    public interface IFilter
+    {
+        bool Apply(JsonElement pubSubEvent);
+    }
+}

--- a/samples/DotnetInDotnet/Filter.Custom/Filter.Custom.csproj
+++ b/samples/DotnetInDotnet/Filter.Custom/Filter.Custom.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Filter.Common\Filter.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/DotnetInDotnet/Filter.Custom/UntrustedCode.cs
+++ b/samples/DotnetInDotnet/Filter.Custom/UntrustedCode.cs
@@ -1,0 +1,22 @@
+﻿using Filter.Common;
+using System.Text.Json;
+
+namespace Filter.Custom
+{
+    // this is the customer code, we expect to have many such filters
+    public class Customer1UntrustedFilter : IFilter
+    {
+        internal static class EventFields
+        {
+            public const string ProductContext = "productContext";
+        }
+
+        public bool Apply(JsonElement pubSubEvent)
+        {
+            var res = pubSubEvent.TryGetProperty(EventFields.ProductContext, out var productContext)
+                && productContext.ValueKind == JsonValueKind.String
+                && productContext.GetString() == "FooBar";
+            return res;
+        }
+    }
+}

--- a/samples/DotnetInDotnet/Filter.ExternalHost/Filter.ExternalHost.csproj
+++ b/samples/DotnetInDotnet/Filter.ExternalHost/Filter.ExternalHost.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Wasmtime" Version="0.40.0-preview1" />
+    <ProjectReference Include="..\Filter.WasmHost\Filter.WasmHost.csproj" ReferenceOutputAssembly="false"/>
+    <ProjectReference Include="..\Filter.Custom\Filter.Custom.csproj" ReferenceOutputAssembly="false"/>
+  </ItemGroup>
+
+  <Target Name="CopyBinaries" AfterTargets="AfterBuild">
+    <ItemGroup>
+      <WASI Include="..\Filter.WasmHost\bin\$(Configuration)\net7.0\Filter.WasmHost.wasm" />
+      <CUSTOM Include="..\Filter.Custom\bin\$(Configuration)\net6.0\*.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(WASI)" DestinationFolder="$(TargetDir)\%(RecursiveDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(CUSTOM)" DestinationFolder="$(TargetDir)\%(RecursiveDir)" SkipUnchangedFiles="true" />
+  </Target>
+
+</Project>

--- a/samples/DotnetInDotnet/Filter.ExternalHost/Program.cs
+++ b/samples/DotnetInDotnet/Filter.ExternalHost/Program.cs
@@ -1,0 +1,39 @@
+﻿#pragma warning disable CS8602
+#pragma warning disable CS8604
+
+using HostingApplication;
+
+public class MainLoop
+{
+    public static void Main()
+    {
+        var container = CreateContainer("Filter.Custom", "Filter.Custom.Customer1UntrustedFilter");
+
+        var pubSubEvent = DocumentSample();
+        const int repeat = 10_000;
+        bool result = false;
+        var start = DateTime.UtcNow;
+        for (var i = 0; i < repeat; i++)
+        {
+            result = container.ApplyFilter(pubSubEvent);
+        }
+        var duration = DateTime.UtcNow - start;
+
+        Console.WriteLine($"filter repeated {repeat} times returned {result} in {duration.TotalMilliseconds}ms ");
+    }
+
+    public static string DocumentSample()
+    {
+        return @"{ 'productContext': 'FooBar' }".Replace('\'', '\"');
+    }
+
+    public static WebAssemblyContainer CreateContainer(string filterAssemblyName, string filterClassName)
+    {
+        const int maxPayloadSizeBytes = 100_000;
+        string fullPath = System.Reflection.Assembly.GetAssembly(typeof(WebAssemblyContainer)).Location;
+        string webAssemblyFileName = Path.Combine(Path.GetDirectoryName(fullPath), "Filter.WasmHost.wasm");
+        string customFilterDllName = Path.Combine(Path.GetDirectoryName(fullPath), filterAssemblyName + ".dll");
+        string asseblyQualifiedFilterName = filterClassName + ", " + filterAssemblyName;
+        return new WebAssemblyContainer(webAssemblyFileName, customFilterDllName, asseblyQualifiedFilterName, maxPayloadSizeBytes);
+    }
+}

--- a/samples/DotnetInDotnet/Filter.ExternalHost/WebAssemblyContainer.cs
+++ b/samples/DotnetInDotnet/Filter.ExternalHost/WebAssemblyContainer.cs
@@ -1,0 +1,132 @@
+﻿#pragma warning disable CS8605
+using System.ComponentModel;
+using System.Text;
+using System.Text.Json;
+using Wasmtime;
+
+namespace HostingApplication;
+
+public class WebAssemblyContainer
+{
+    private readonly Engine _engine;
+    private readonly Module _module;
+    private readonly Linker _linker;
+    private readonly Store _store;
+    private readonly Instance _instance;
+    private readonly Function _malloc;
+    private readonly Function _loadDll;
+    private readonly Function _installFilter;
+    private readonly Function _apply;
+    private readonly Memory _memory;
+    private static int jsonBufferPtr;
+    private byte[] payloadMemory;
+
+    // API doc https://bytecodealliance.github.io/wasmtime-dotnet/api/Wasmtime.Engine.html
+    public WebAssemblyContainer(string webAssemblyFileName, string customFilterDllName, string asseblyQualifiedFilterName, int maxPayloadSizeBytes)
+    {
+        if (!File.Exists(webAssemblyFileName)) throw new FileNotFoundException(webAssemblyFileName);
+        if (!File.Exists(customFilterDllName)) throw new FileNotFoundException(customFilterDllName);
+        // RUST_BACKTRACE=1
+        try
+        {
+            var config = new Config()
+                .WithReferenceTypes(false)
+                .WithWasmThreads(false)
+                .WithCompilerStrategy(CompilerStrategy.Cranelift)
+                .WithMaximumStackSize(10_000_000)
+                .WithOptimizationLevel(OptimizationLevel.Speed)
+            ;
+            _engine = new Engine(config);
+            _module = Module.FromFile(_engine, webAssemblyFileName);
+            _linker = new Linker(_engine);
+            _linker.DefineWasi();
+
+            _store = new Store(_engine);
+            var c = new WasiConfiguration()
+                .WithInheritedStandardOutput()
+                //.WithEnvironmentVariable("MONO_LOG_LEVEL", "debug")
+                .WithEnvironmentVariable("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "1")
+                ;
+            _store.SetWasiConfiguration(c);
+
+            _instance = _linker.Instantiate(_store, _module);
+            _memory = _instance.GetMemory("memory")!;
+            if (_memory == null) throw new InvalidOperationException("memory");
+
+            _malloc = _instance.GetFunction("malloc")!;
+            if (_malloc == null) throw new InvalidOperationException("malloc");
+            _loadDll = _instance.GetFunction("loadDll")!;
+            if (_loadDll == null) throw new InvalidOperationException("loadDll");
+            _apply = _instance.GetFunction("apply")!;
+            if (_apply == null) throw new InvalidOperationException("apply");
+            _installFilter = _instance.GetFunction("installFilter")!;
+            if (_installFilter == null) throw new InvalidOperationException("installFilter");
+
+            payloadMemory = new byte[maxPayloadSizeBytes];
+
+            LoadDll(customFilterDllName);
+            Start();
+            LoadFilter(asseblyQualifiedFilterName, maxPayloadSizeBytes);
+        }
+        catch (Exception ex)
+        {
+            _engine?.Dispose();
+            Console.WriteLine(ex.ToString());
+            throw;
+        }
+    }
+
+    private unsafe void LoadDll(string customFilterDllName)
+    {
+        var shortDllName = Path.GetFileName(customFilterDllName);
+        var dllNameBuffer = (int)_malloc.Invoke(shortDllName.Length * 2);
+        if (dllNameBuffer == 0) throw new InvalidOperationException();
+        var bytes = _memory.WriteString(dllNameBuffer, shortDllName, Encoding.UTF8);
+        _memory.WriteByte(dllNameBuffer + bytes, 0);// zero terminated
+
+        byte[] dllBytes = File.ReadAllBytes(customFilterDllName);
+        var dllBytesBuffer = (int)_malloc.Invoke(dllBytes.Length);
+        if (dllBytesBuffer == 0) throw new InvalidOperationException();
+
+        var dllBufferSpan = _memory.GetSpan<byte>(dllBytesBuffer);
+        var dllSource = new Span<byte>(dllBytes);
+        dllSource.CopyTo(dllBufferSpan);
+
+        _loadDll.Invoke(dllNameBuffer, dllBytesBuffer, dllBytes.Length);
+    }
+
+    private unsafe void Start()
+    {
+        var _start = _instance.GetFunction("_start")!;
+        if (_start == null) throw new InvalidOperationException("_start");
+        _start.Invoke();
+    }
+
+    private unsafe void LoadFilter(string asseblyQualifiedFilterName, int maxPayloadSizeBytes)
+    {
+        var filterNameBuffer = (int)_malloc.Invoke(asseblyQualifiedFilterName.Length * 2);
+        if (filterNameBuffer == 0) throw new InvalidOperationException();
+        var bytes = _memory.WriteString(filterNameBuffer, asseblyQualifiedFilterName, Encoding.UTF8);
+        _memory.WriteByte(filterNameBuffer + bytes, 0);// zero terminated
+
+        jsonBufferPtr = ((int)_installFilter.Invoke(filterNameBuffer, bytes, maxPayloadSizeBytes)!);
+    }
+
+    private bool ApplyFilter(ReadOnlyMemory<byte> eventUtf8Json)
+    {
+        var jsonBufferSpan = _memory.GetSpan<byte>(jsonBufferPtr);
+        eventUtf8Json.Span.CopyTo(jsonBufferSpan);
+        var filterResult = ((int)_apply.Invoke(eventUtf8Json.Length)!);
+        return filterResult == 1;
+    }
+
+    public bool ApplyFilter(string json)
+    {
+        // the dotnet inside of the WASI host is not ready for threads
+        lock (_engine)
+        {
+            var bytes = Encoding.UTF8.GetBytes(json, payloadMemory.AsSpan());
+            return ApplyFilter(new ReadOnlyMemory<byte>(payloadMemory, 0, bytes));
+        }
+    }
+}

--- a/samples/DotnetInDotnet/Filter.WasmHost/BundleMyReferences.cs
+++ b/samples/DotnetInDotnet/Filter.WasmHost/BundleMyReferences.cs
@@ -1,0 +1,25 @@
+﻿using System.Text.Json;
+
+namespace Dummy
+{
+    // this dummy class is here to make sure that wasm SDK linker knows which DLLs we need bundled
+    public class BundleMyReferences
+    {
+        public bool Apply(ReadOnlyMemory<byte> eventUtf8Json)
+        {
+            try
+            {
+                var doc = JsonDocument.Parse(eventUtf8Json);
+                var root = doc.RootElement;
+
+                return root.TryGetProperty("dummy", out var productContext)
+                    && productContext.ValueKind == JsonValueKind.String
+                    && productContext.GetString() == "dummy";
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/samples/DotnetInDotnet/Filter.WasmHost/Filter.WasmHost.csproj
+++ b/samples/DotnetInDotnet/Filter.WasmHost/Filter.WasmHost.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net7.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\src\Wasi.Sdk\Wasi.Sdk.csproj" ReferenceOutputAssembly="false" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<WasiNativeFileReference Include="$(MSBuildThisFileDirectory).\native\*.c" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\Filter.Common\Filter.Common.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<UpToDateCheckInput Include="native\interop.c" />
+		<UpToDateCheckInput Include="native\dotnet_method.h" />
+		<WasiAfterRuntimeLoaded Include="native_attach" />
+	</ItemGroup>
+</Project>

--- a/samples/DotnetInDotnet/Filter.WasmHost/InnerHost.cs
+++ b/samples/DotnetInDotnet/Filter.WasmHost/InnerHost.cs
@@ -1,0 +1,57 @@
+﻿#pragma warning disable CS8618
+using System.Text;
+using System.Diagnostics.CodeAnalysis;
+using Filter.Common;
+using System.Runtime.InteropServices;
+using Dummy;
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace Filter.WasmHost
+{
+    public static class InnerHost
+    {
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(BundleMyReferences))]
+        public static void Main()
+        {
+        }
+
+        private static IFilter Filter;
+        private static byte[] Buffer;
+
+        public unsafe static IntPtr InstallFilter(byte* asseblyQualifiedFilterNamePtr, int asseblyQualifiedFilterNameLen, int bufferSize)
+        {
+            var asseblyQualifiedFilterName = Encoding.UTF8.GetString(asseblyQualifiedFilterNamePtr, asseblyQualifiedFilterNameLen);
+            var filterType = Type.GetType(asseblyQualifiedFilterName);
+            Debug.Assert(filterType != null, "InnerHost.InstallFilter type not found" + asseblyQualifiedFilterName);
+
+            var filter = Activator.CreateInstance(filterType) as IFilter;
+            Debug.Assert(filter != null, "InnerHost.InstallFilter failed to create instance" + asseblyQualifiedFilterName);
+
+            Filter = filter;
+            Buffer = new byte[bufferSize];
+
+            var pinnedArray = GCHandle.Alloc(Buffer, GCHandleType.Pinned);
+            var ptr = pinnedArray.AddrOfPinnedObject();
+            return ptr;
+        }
+
+        public unsafe static int Apply(int lenght)
+        {
+            try
+            {
+                ReadOnlyMemory<byte> eventUtf8Json = new(Buffer, 0, lenght);
+                var doc = JsonDocument.Parse(eventUtf8Json);
+                GC.Collect();
+
+                return Filter.Apply(doc.RootElement) ? 1 : 0;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(ex.ToString());
+                return 0;
+            }
+        }
+    }
+}

--- a/samples/DotnetInDotnet/Filter.WasmHost/native/dotnet_method.h
+++ b/samples/DotnetInDotnet/Filter.WasmHost/native/dotnet_method.h
@@ -1,0 +1,13 @@
+#define DEFINE_DOTNET_METHOD(c_name, assembly_name, namespc, class_name, method_name) \
+MonoMethod* method_##c_name;\
+MonoObject* c_name(MonoObject* target_instance, void* method_params[]) {\
+    if (!method_##c_name) {\
+        method_##c_name = lookup_dotnet_method(assembly_name, namespc, class_name, method_name, -1);\
+        assert(method_##c_name);\
+    }\
+\
+    MonoObject* exception;\
+    MonoObject* res = mono_wasm_invoke_method(method_##c_name, target_instance, method_params, &exception);\
+    assert(!exception);\
+    return res;\
+}

--- a/samples/DotnetInDotnet/Filter.WasmHost/native/interop.c
+++ b/samples/DotnetInDotnet/Filter.WasmHost/native/interop.c
@@ -1,0 +1,54 @@
+﻿#include <mono-wasi/driver.h>
+#include <assert.h>
+#include "dotnet_method.h"
+
+void noop_settimeout(int timeout) {
+    // Not implemented
+}
+
+DEFINE_DOTNET_METHOD(invoke_threadpool_callback, "System.Private.CoreLib.dll", "System.Threading", "ThreadPool", "Callback");
+void wasi_queuecallback() {
+    invoke_threadpool_callback(NULL, NULL);
+}
+
+
+MonoMethod* method_Apply;
+MonoMethod* method_InstallFilter;
+
+void native_attach() {
+    mono_add_internal_call("System.Threading.TimerQueue::SetTimeout", noop_settimeout);
+    mono_add_internal_call("System.Threading.ThreadPool::QueueCallback", wasi_queuecallback);
+
+    method_Apply = lookup_dotnet_method("Filter.WasmHost.dll", "Filter.WasmHost", "InnerHost", "Apply", -1);
+    assert(method_Apply);
+    method_InstallFilter = lookup_dotnet_method("Filter.WasmHost.dll", "Filter.WasmHost", "InnerHost", "InstallFilter", -1);
+    assert(method_InstallFilter);
+}
+
+__attribute__((export_name("loadDll")))
+void loadDll(void* dllName, const unsigned char *dllDataPtr, unsigned int dllDataLenght) {
+    assert(mono_wasm_add_assembly (dllName, dllDataPtr, dllDataLenght));
+    free(dllName);
+}
+
+__attribute__((export_name("installFilter")))
+int installFilter(void* filterNamePtr,unsigned int filterNameLength, unsigned int bufferLength) {
+    void* method_params[] = { filterNamePtr, &filterNameLength, &bufferLength };
+    MonoObject* exception;
+    MonoObject* res = mono_wasm_invoke_method(method_InstallFilter, NULL, method_params, &exception);
+    assert(!exception);
+    assert(res);
+    free(filterNamePtr);
+    int ptr=mono_unbox_int(res);
+    assert(ptr);
+    return ptr;
+}
+
+__attribute__((export_name("apply")))
+int apply(int lenghtBytes) {
+    void* method_params[] = { &lenghtBytes };
+    MonoObject* exception;
+    MonoObject* res = mono_wasm_invoke_method(method_Apply, NULL, method_params, &exception);
+    assert(!exception);
+    return mono_unbox_int(res);
+}

--- a/samples/DotnetInDotnet/README.md
+++ b/samples/DotnetInDotnet/README.md
@@ -1,0 +1,15 @@
+# Assembly isolation using WASI sandbox
+
+This sample shows how to
+- use [wasmtime-dotnet](https://github.com/bytecodealliance/wasmtime-dotnet) wrapper API around wasmtime engine
+  - configure it for WASI
+  - call exported functions
+  - map memory
+- load untrusted DLL into runtime inside of WASM process
+- marshal json payload as bytes
+- dispatch call to untrusted component
+
+
+## TODO
+- runtime fails on first GC
+- dependencies of the untrusted DLL are not included


### PR DESCRIPTION
This sample shows how to
- use [wasmtime-dotnet](https://github.com/bytecodealliance/wasmtime-dotnet) wrapper API around wasmtime engine
  - configure it for WASI
  - call exported functions
  - map memory
- load untrusted DLL into runtime inside of WASM process
- marshal json payload as bytes
- dispatch call to untrusted component


created as part of MSFT hackathon 2022