### PR TITLE
Use --force-local in tar

### DIFF
--- a/src/Wasi.Sdk/build/Wasi.Sdk.targets
+++ b/src/Wasi.Sdk/build/Wasi.Sdk.targets
@@ -257,7 +257,7 @@
 		<!-- Windows 10+ has tar built in, so this should work cross-platform -->
 		<Message Importance="high" Text="Extracting @(WasiSdkDownloadTempFile) to $(WasiSdkRoot)..." />
 		<MakeDir Directories="$(WasiSdkRoot)" />
-		<Exec Command="tar -xf &quot;@(WasiSdkDownloadTempFile)&quot; -C . --strip-components=1" WorkingDirectory="$(WasiSdkRoot)" />
+		<Exec Command="tar -xf &quot;@(WasiSdkDownloadTempFile)&quot; -C . --strip-components=1 --force-local" WorkingDirectory="$(WasiSdkRoot)" />
 		<RemoveDir Directories="$(WasiSdkDownloadTempDir)" />
 	</Target>
 


### PR DESCRIPTION
Fixes "tar: Cannot connect to C: resolve failed"

Implementations of tar interpret path as `hostname:path` when given the opportunity, causing issues when given standard Windows absolute paths. `--force-local` should be used to prevent this behaviour, which is not required here since the temporary path should always be local.

References:
https://stackoverflow.com/questions/12823499/windows-command-line-tar-cannot-connect-to-d-resolve-failed-with-chef-knife https://superuser.com/questions/287233/tar-command-to-extract-archive-with-colon-in-the-name